### PR TITLE
Define owner and file permissions for keyboard config file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,9 @@
     src: keyboards.j2
     dest: /etc/default/keyboard
     force: true
+    owner: root
+    group: root
+    mode: 'u=rw,go=r'
 
 - name: apply keyboard configration
   command: /usr/sbin/dpkg-reconfigure -f noninteractive keyboard-configuration


### PR DESCRIPTION
While the defaults work it's best to be explicit.