### PR TITLE
Adopted yes|no convention for booleans

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   template:
     src: keyboards.j2
     dest: /etc/default/keyboard
-    force: true
+    force: yes
     owner: root
     group: root
     mode: 'u=rw,go=r'


### PR DESCRIPTION
Ansible supports `true|false` and `yes|no` (with varying case) for boolean values; the Ansible documentation is wildly inconsistent on which it uses, so it's easy to end up with a mixture.

It's better to be consistent, so `yes|no` is now the convention for all Ansible roles written by GantSign.