### PR TITLE
Renamed handler to be more specific

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: apply keyboard configration
+- name: dpkg-reconfigure keyboard-configuration
   become: yes
   command: /usr/sbin/dpkg-reconfigure -f noninteractive keyboard-configuration
   when: ansible_os_family == 'Debian'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,4 +16,4 @@
     group: root
     mode: 'u=rw,go=r'
   notify:
-    - apply keyboard configration
+    - dpkg-reconfigure keyboard-configuration


### PR DESCRIPTION
Since the handler is global it should be more specific as to it's purpose.