### PR TITLE
Dropped documented support for Ubuntu Wily

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Requirements
         * Ubuntu
 
             * Trusty (14.04)
-            * Wily (15.10)
             * Xenial (16.04)
 
 Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
-    - wily
     - xenial
   - name: Debian
     versions:


### PR DESCRIPTION
It's no longer a supported Ubuntu version.