### PR TITLE
Changed test to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -6,8 +6,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_keyboard_file(File):
-    kb = File('/etc/default/keyboard')
+def test_keyboard_file(host):
+    kb = host.file('/etc/default/keyboard')
 
     assert kb.exists
     assert kb.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.