### PR TITLE
Dropped support for Debian Wheezy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Wheezy (7)
             * Jessie (8)
             * Stretch (9)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
       versions:
         - stretch
         - jessie
-        - wheezy
   galaxy_tags:
     - keyboard
     - ubuntu

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-keyboard-debian-min
-    image: debian:7
+    image: debian:8
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian ended support in May 2018.