### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: Keyboard
 ======================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-keyboard.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-keyboard)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-keyboard.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-keyboard)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.keyboard-blue.svg)](https://galaxy.ansible.com/gantsign/keyboard)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-keyboard/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.