### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,6 @@ galaxy_info:
       versions:
         - buster
         - stretch
-        - jessie
   galaxy_tags:
     - keyboard
     - ubuntu

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-keyboard-debian-min
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Debian ended LTS support in June 2020.